### PR TITLE
ROC-3269: Fix exports syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,25 @@
-export const supportedBrowsers = {
-  'ie11_win10': {
-    'browserName': 'internet explorer',
-    'name': 'IE11_Win10',
-    'platform': 'Windows 10',
-    'ignoreZoomSetting': true,
-    'nativeEvents': false,
-    'ignoreProtectedModeSettings': true,
-    'version': '11'
-  },
-  'chrome_win_latest': {
-    'browserName': 'chrome',
-    'name': 'WIN_CHROME_LATEST',
-    'platform': 'Windows 10',
-    'version': 'latest'
-  },
-  'firefox_win_latest': {
-    'browserName': 'firefox',
-    'name': 'WIN_FIREFOX_LATEST',
-    'platform': 'Windows 10',
-    'version': 'latest'
+module.exports = {
+  supportedBrowsers: {
+    'ie11_win10': {
+      'browserName': 'internet explorer',
+      'name': 'IE11_Win10',
+      'platform': 'Windows 10',
+      'ignoreZoomSetting': true,
+      'nativeEvents': false,
+      'ignoreProtectedModeSettings': true,
+      'version': '11'
+    },
+    'chrome_win_latest': {
+      'browserName': 'chrome',
+      'name': 'WIN_CHROME_LATEST',
+      'platform': 'Windows 10',
+      'version': 'latest'
+    },
+    'firefox_win_latest': {
+      'browserName': 'firefox',
+      'name': 'WIN_FIREFOX_LATEST',
+      'platform': 'Windows 10',
+      'version': 'latest'
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-supported-browsers",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "HMCTS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
CommonJS exports syntax has to be used if we're using plain JavaScript (TypeScript can compile ES6 syntax into CommonJS for us).